### PR TITLE
make rauc updates possible

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -201,6 +201,12 @@ jobs:
           VERSION_DEV: ${{ needs.prepare.outputs.version_dev }}
         run: |
           sed -i -E "s/(^VERSION_SUFFIX=\").*(\"$)/\1${VERSION_DEV}\2/" buildroot-external/meta
+      
+      - name: Get self-signed certificate from the prepare job
+        if: ${{ needs.prepare.outputs.self_signed_cert == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: signing-key
 
       - name: Build
         run: |
@@ -224,8 +230,8 @@ jobs:
             BR2_CHECK_DOTCONFIG_OPTS="--github-format --strip-path-prefix=/build/" linux-check-dotconfig
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: haos-image
-          path: output/images/haos_*.img.xz
+          path: output/images/haos_*
           if-no-files-found: error


### PR DESCRIPTION
I was trying to have a smoother update path for the OS instead of reflashing for each release and stumbled upon [this](https://developers.home-assistant.io/docs/operating-system/update-system/#updating-to-a-development-build) documentation of how it's supposed to work for development builds.

Unfortunately this didn't work out of the box and rauc continued to complain about "Verify error: self-signed certificate".
Upon comparing your build workflow with the upstream one i noticed the missing download step of the self-signed certificate.

With the changes of this PR I was able to update my board as described in the docu mentioned above.
When you publish a release you would have to upload the rauc bundles (*.raucb) and the certificate (cert.pem) too, so everybody could update his install this smooth. 

Oh.. and probably the README should hint at this update possibility..